### PR TITLE
Use only first two principal components with non-robust PCA

### DIFF
--- a/R/detect_outliers.R
+++ b/R/detect_outliers.R
@@ -21,7 +21,7 @@ anomaly <- function(x, n = 10, method = c("hdr", "ahull"), robust = TRUE,
     rbt.pca <- princomp(scale(naomit.x, center = TRUE, scale = TRUE), 
                         cor = TRUE)
   }
-  scores <- rbt.pca$scores
+  scores <- rbt.pca$scores[,1:2] #make non-robust PCA work, prevent dimension mismatch below
   scoreswNA <- matrix(, nrow = nc, ncol = 2)
   scoreswNA[avl, ] <- scores
   tmp.idx <- vector(length = n)


### PR DESCRIPTION
Using the `robust=FALSE` flag results in an error "number of items to replace is not a multiple of replacement length" because PCA  a scores matrix with greater than 2 components which `princomp` will do, but won't occur because of `k=2` in the call to `pcaPP::PCAproj`

Suggested fix: just take the first two columns of scores.

I'd not that I get surprisingly different results between robust and non-robust PCA with hdr on a quick test I did and visually the robust results make more sense. Also your paper seems to suggest better performance when not using robust PCA but the default in the R code is `robust=TRUE`.
